### PR TITLE
Fix some Blade snippets not working

### DIFF
--- a/snippets/Blade/Blade-can.sublime-snippet
+++ b/snippets/Blade/Blade-can.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
     <content><![CDATA[
 @can('${1:ability}', ${2:\$object})
-    ${3//}
+    ${3}
 @else
-	${4//}
+	${4}
 @endcan
 ]]></content>
     <tabTrigger>Blade::can</tabTrigger>

--- a/snippets/Blade/Blade-cannot.sublime-snippet
+++ b/snippets/Blade/Blade-cannot.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @cannot('${1:ability}', ${2:\$object})
-    ${3//}
+    ${3}
 @endcannot
 ]]></content>
     <tabTrigger>Blade::cannot</tabTrigger>

--- a/snippets/Blade/Blade-for.sublime-snippet
+++ b/snippets/Blade/Blade-for.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @for (${1:\$i} = ${2:0}; ${1:\$i} < ${3:10}; ${1:\$i}++)
-	${4//}
+	${4}
 @endfor
 ]]></content>
     <tabTrigger>Blade::for</tabTrigger>

--- a/snippets/Blade/Blade-foreach.sublime-snippet
+++ b/snippets/Blade/Blade-foreach.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @foreach (${1:\$records} as ${2:\$record})
-	${3//}
+	${3}
 @endforeach
 ]]></content>
     <tabTrigger>Blade::foreach</tabTrigger>

--- a/snippets/Blade/Blade-forelse.sublime-snippet
+++ b/snippets/Blade/Blade-forelse.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
     <content><![CDATA[
 @foreach (${1:\$records} as ${2:\$record})
-	${3//}
+	${3}
 @forelse
-	${4//}
+	${4}
 @endforelse
 ]]></content>
     <tabTrigger>Blade::forelse</tabTrigger>

--- a/snippets/Blade/Blade-if.sublime-snippet
+++ b/snippets/Blade/Blade-if.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @if (${1:\$condition})
-	${2//}
+	${2}
 @endif
 ]]></content>
     <tabTrigger>Blade::if</tabTrigger>

--- a/snippets/Blade/Blade-ifelse.sublime-snippet
+++ b/snippets/Blade/Blade-ifelse.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
     <content><![CDATA[
 @if (${1:\$condition})
-	${2//}
+	${2}
 @else
-	${3//}
+	${3}
 @endif
 ]]></content>
     <tabTrigger>Blade::ifelse</tabTrigger>

--- a/snippets/Blade/Blade-push.sublime-snippet
+++ b/snippets/Blade/Blade-push.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @push('${1:stack name}')
-	${2//}
+	${2}
 @endpush
 ]]></content>
     <tabTrigger>Blade::push</tabTrigger>

--- a/snippets/Blade/Blade-section.sublime-snippet
+++ b/snippets/Blade/Blade-section.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @section('${1:content}')
-	${2//}
+	${2}
 @stop
 ]]></content>
     <tabTrigger>Blade::section</tabTrigger>

--- a/snippets/Blade/Blade-unless.sublime-snippet
+++ b/snippets/Blade/Blade-unless.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @unless (${1:\$condition})
-	${2//}
+	${2}
 @endunless
 ]]></content>
     <tabTrigger>Blade::unless</tabTrigger>

--- a/snippets/Blade/Blade-while.sublime-snippet
+++ b/snippets/Blade/Blade-while.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 @while (${1:\$condition})
-	${2//}
+	${2}
 @endwhile
 ]]></content>
     <tabTrigger>Blade::while</tabTrigger>


### PR DESCRIPTION
Some Blade snippets were left with a '//' within the tab order, preventing its use. Removing them solved the problem.
